### PR TITLE
🎉 feat(upgrade): upgrade to spilo 11 1.6-p1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
 version: 0.12.1
-appVersion: 1.4-p16
+appVersion: 1.6-p1
 home: https://github.com/zalando/patroni
 sources:
 - https://github.com/zalando/patroni

--- a/templates/statefulset-patroni.yaml
+++ b/templates/statefulset-patroni.yaml
@@ -27,6 +27,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: PGVERSION
+          value: "10"
         - name: PGPASSWORD_SUPERUSER
           valueFrom:
             secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,8 @@ replicaCount: 5
 image:
   # Image was built from
   # https://github.com/zalando/spilo/tree/master/postgres-appliance
-  repository: registry.opensource.zalan.do/acid/spilo-10
-  tag: 1.4-p16
+  repository: registry.opensource.zalan.do/acid/spilo-11
+  tag: 1.6-p1
   pullPolicy: IfNotPresent
 
 # Credentials used by Patroni


### PR DESCRIPTION
@ronanamsterdam @nandiheath you may need to know the background

### Why we need to upgrade
on Sep 27, after redeploying patroni (to increase the memory), we found the secondaries kept failing. @bappr asked the issue on their repo
https://github.com/zalando/patroni/issues/570#issuecomment-535763542

The guy from patroni gave us a command to fix it, also suggested us to upgrade the docker image as it's outdated.
```
that's quite an old image, it was build more than a year ago...
```

### Tested cases
both cases are tested with replicaCount=1 and 3
1. a new deployment on a new environment
2. upgrade from existing patroni from `master` branch (see limitation below)

### enviroments tested
1. new env (hasura)
2. my env (edward)

### limitation
cs-patroni-x will not restart after deployment, two workarounds:
1. (no downtime)kubectl: maunally `kubectl delete pod cs-patroni-x`
2. (has downtime)Kintohub UI: remove `patroni` -> deploy -> add back `patroni` -> deploy

